### PR TITLE
Add chat client and server scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,15 @@
-# KWS-
-chat systhem made out of python scripts.in the ChatDirektory you can find the programm to install,and in the ServerDirektory is a py script,that anyone can run on his host server,there can be more than one of these server scripts launched,beacouse they are decentralized and work together to sustain the chat programm,that the users use.based on kws. https://github.com/Alan107-gif/kws follow the link or you see it at the and of this letter.
+# KWS Chat System
 
----
->  (nur systembibliotheken)also das wäre der "instance-kws.sh/bash" 2 bashscripte für windows und linux, erstellt im homeverzeichnis einen ordner namens "kws" und ladet von urls (eine url für einen script außer dem instance installator) die scripte herrunter: (kws.py(-main script der ständig arbeiten muss), kws-client.py kws-service.py). das instance-kws wird zum beispiel von meiner github-seite herruntergeladen. "kws.py": ist der main script, er erstellt einen file in dem ordner mit den anderen scripten, der den key enthält, der auth.key ist sozusagen die intentification nummer des nutzers, dann gibt es noch den "config.cfk"-file da drin unter anderem kann man auch den usernamen eingeben und andere einstellungen, alle scripte teilen sich diesen file. ... weiteres müssen wir noch besprechen darunter "contaktd.cdf"-file
-so, und jetzt zu kws.py kws-client.py und kws-service.py. es wird ein kommunikationsnetz, in contaktd.cdf wird jede zeile ein neuer gespeicherter kontakt sein bsp.: zeile 1: max-mustermann; <auth-id>; <last contact(letzte contaktzeit)>;  <benutzerdefinierter-name(diesen namen kann der nutzer direkt in dieser datei ändern, damit er bsp kontakte mit kleichen usernames unterscheiden kann.)>; ip-adress; status(online/offline)|. so, es wird ein netz wie das netz der mubilfunktürme, nur halt zwischen computern. kws-client.py kommuniziert und fragt durch den server (kws.py) informationen ab und sendet datenpakete ständig an alle auf der liste, die liste (contaktd.cdf) wird auch ständig ergänst. kws-service.py ist die benutzeroberfläche... mit seiner eigenen reihe an befehlen: Help; Add <auth-id> (manuelles hizufügen); List (alle schöpn auflisten); Message <ben.def.usr.name> <'the actual message'>; Show (antwort: auth-id/ben.def.usr.name: <message from the user>; auth...); Request <auth-id/ben.def.usr.name> <List/Add.../Status>.  außerdem sollte es noch einen file- "datatrans.ksys" geben, wo die ganzen nachrichten strukturiert gehalten werden(nicht dazu gedacht damit der nutzer reunschaut). wenn der andere nutzer nicht online ist. an alle, die vorraussichtlich das ganze auch installiert haben werden kleine pakete gesendet und wenn deren script antwortet wird eine verbindung hergestellt, und es geschieht ein datenaustausch(inklusive der nachrichten: die nachrichten werden mit absendezeit gespeichert). ich erlaube auch mehrere .ksys -files zum hantieren von daten... . der script kws.py fragt alle auf der contactd... liste nacheinander ab. ich brauche die vollen codes, du kannst sie auch auf blöcke teilen, die ich dann nacheinander in meinen editor einfügen kann.
-datatrans.ksys ist ja die dauerhafte zwischenspeicherung der nachrichten, und die REQ - befehle sollen erweitert sein erweitere sie bitte also REQ <adresse(auth id)> <befehl, der auf dem addressierten computer ausgeführt werden soll>. meine auth id wird automatisch mitgesendet.
-so umändern, dass die auch alle anderen dateien erstellen(falls mnötig)und die scripte zusammen arbeiten und vom kws.py gestartet werden, und wenn ich kws-service in python starte kann ich einfach die bvefehle mauel eingeben, eigentlich erfolg6t5 die kommunikation automatisch der befehl der neue befehl REQUEST <auth-id-target> <ADD<LIST>/LIST> (add list heißt meine liste dem target-computer teilen/ADD= selektives hinzufügen/ LIST = die liste dieses computers anfragen) die liste der kontakte wie ich schon gedagt habe ist in "cantactd", und die listen, antworten und requests, die nicht abgeschickt werden konnten weil das target offline war sind in "datatrans.ksys"+"data.ksys(dauerhaft)" sobalt eine automatische verbindung hergestellt wird werden die angestauten informationen gegenseitig übermittelt. bsp : weitere einstellungen: ping/verbindungsprüfungsintervall
+This repository provides a minimal implementation of the KWS chat concept.
+It consists of two parts:
 
----
-> kws
->
-> Kontakt-work-Station is a decentralized communication network like mobile towers.
-> 
-> KWS - Kommunikationsnetzwerk -OpenScource!
-> 
-> Beschreibung: KWS ist eine leichte, in Python implementierte Lösung für ein dezentrales Kommunikationsnetz. Das System stellt eine direkte, computer-zu-computer Verbindung her – ähnlich einem Mesh-Netzwerk. Es besteht aus drei Hauptkomponenten: •  kws.py – der Server, der dauerhaft läuft, einen einzigartigen Auth-Key generiert und Konfigurations- sowie Kontaktdateien (contaktd.cdf) verwaltet. • kws-client.py – der Client, der periodisch Anfragen (z. B. INFO) an alle Kontakte sendet undfehlgeschlagene Nachrichten in einer Datei (data.ksys) zwischenspeichert. • kws-service.py – eine Befehlszeilenschnittstelle, über die der Nutzer Kontakte hinzufügen, Nachrichten senden und Anfragen (z. B. ADDLIST, LIST) manuell auslösen kann.
->
-> Vorteile: • Leichtgewichtig: Es werden nur systemeigene Bibliotheken (Sockets, Threading etc.) genutzt. • Dezentral: Jeder Rechner agiert als Knoten in einem Netzwerk, ohne zentrale Serverabhängigkeit. • Flexibel: Erweiterte Befehle ermöglichen das >Teilen von Kontaktlisten, selektives Hinzufügen von Kontakten und automatische Synchronisation. • Offline-Nachrichten: Nachrichten, die nicht sofort zugestellt werden können, werden zwischengespeichert und bei Wiederverbindung automatisch gesendet. • > Einfache Installation: Mit den beiliegenden Installationsskripten (instance-kws.sh für Linux, instance-kws.bat für Windows) wird ein ZIP-Paket heruntergeladen, entpackt und ein Autostart eingerichtet.
+* `chat/` – client scripts including `KWS_Main.py` and `kws_setup.py`.
+* `server/` – the relay server script `kws_server.py`.
+
+Run the client using Python. On first start it installs itself under `~/KWS`
+and creates the required data files. After the setup message
+"Installation Done, Need to restart the Script." restart the client to use the
+chat.
+
+The server can be started with `python kws_server.py` and kept running
+permanently. Use the `-d` flag for verbose output.

--- a/chat/KWS_Main.py
+++ b/chat/KWS_Main.py
@@ -1,0 +1,70 @@
+import os
+import ssl
+import socket
+import threading
+import sys
+from pathlib import Path
+
+import kws_setup
+
+HOME_DIR = Path.home() / 'KWS'
+CONFIG_FILE = HOME_DIR / 'config.cfk'
+
+DEFAULT_SERVER = 'localhost:5000'
+
+def ensure_setup():
+    if not HOME_DIR.exists():
+        kws_setup.setup()
+        sys.exit(0)
+
+
+def load_config():
+    server = DEFAULT_SERVER
+    username = 'user'
+    if CONFIG_FILE.exists():
+        with open(CONFIG_FILE) as f:
+            for line in f:
+                if line.startswith('server='):
+                    server = line.strip().split('=', 1)[1]
+                if line.startswith('username='):
+                    username = line.strip().split('=', 1)[1]
+    else:
+        with open(CONFIG_FILE, 'w') as f:
+            f.write(f'server={server}\nusername={username}\n')
+    host, port = server.split(':')
+    return username, host, int(port)
+
+
+def recv_loop(sock):
+    while True:
+        data = sock.recv(4096)
+        if not data:
+            break
+        print('\n<', data.decode(), '>')
+
+
+def send_loop(sock):
+    try:
+        while True:
+            msg = input('> ')
+            if msg:
+                sock.sendall(msg.encode())
+    except EOFError:
+        pass
+
+
+def main():
+    ensure_setup()
+    username, host, port = load_config()
+    context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    with socket.create_connection((host, port)) as raw_sock:
+        with context.wrap_socket(raw_sock, server_hostname=host) as sock:
+            sock.sendall(username.encode())
+            threading.Thread(target=recv_loop, args=(sock,), daemon=True).start()
+            send_loop(sock)
+
+
+if __name__ == '__main__':
+    main()

--- a/chat/README.md
+++ b/chat/README.md
@@ -1,0 +1,13 @@
+# KWS Chat Client
+
+This directory contains the client portion of the KWS chat system.
+
+## Usage
+
+1. Run `python KWS_Main.py` to start the client.
+2. On first run the script creates `~/KWS` and moves the client files there.
+3. After setup you need to restart the script. On subsequent runs the chat
+   connects to the server and allows encrypted communication.
+
+The client communicates with the server via TLS (using Python's `ssl` module).
+

--- a/chat/kws_setup.py
+++ b/chat/kws_setup.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+import sys
+import secrets
+
+
+def setup():
+    home = os.path.expanduser("~")
+    target_dir = os.path.join(home, "KWS")
+    if not os.path.exists(target_dir):
+        os.makedirs(target_dir)
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # Move all .py files to the target directory
+    for fname in os.listdir(current_dir):
+        if fname.endswith('.py'):
+            src = os.path.join(current_dir, fname)
+            dst = os.path.join(target_dir, fname)
+            if src != dst:
+                shutil.copy2(src, dst)
+
+    # Create data files
+    auth_file = os.path.join(target_dir, 'auth.key')
+    config_file = os.path.join(target_dir, 'config.cfk')
+    contacts_file = os.path.join(target_dir, 'contacts.cdf')
+    data_file = os.path.join(target_dir, 'datatrans.ksys')
+
+    if not os.path.exists(auth_file):
+        with open(auth_file, 'w') as f:
+            f.write(secrets.token_hex(16))
+
+    for fpath in (config_file, contacts_file, data_file):
+        if not os.path.exists(fpath):
+            open(fpath, 'w').close()
+
+    print('Installation Done, Need to restart the Script.')
+
+if __name__ == '__main__':
+    setup()

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,13 @@
+# KWS Server
+
+This directory contains a simple relay server for the KWS chat system.
+
+Run the server permanently on a host machine:
+
+```bash
+python kws_server.py [-d]
+```
+
+Use the `-d` option to print detailed debug output.
+
+The server accepts TLS connections from clients and relays messages between them.

--- a/server/kws_server.py
+++ b/server/kws_server.py
@@ -1,0 +1,55 @@
+import argparse
+import ssl
+import socket
+import threading
+
+clients = set()
+
+
+def handle_client(conn, addr, debug):
+    try:
+        username = conn.recv(1024).decode()
+        if debug:
+            print(f"{username} connected from {addr}")
+        clients.add(conn)
+        while True:
+            data = conn.recv(4096)
+            if not data:
+                break
+            msg = f"{username}: {data.decode()}"
+            for c in list(clients):
+                if c is not conn:
+                    try:
+                        c.sendall(msg.encode())
+                    except Exception:
+                        clients.discard(c)
+    finally:
+        clients.discard(conn)
+        conn.close()
+        if debug:
+            print(f"{addr} disconnected")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', action='store_true', help='debug output')
+    parser.add_argument('--host', default='0.0.0.0')
+    parser.add_argument('--port', type=int, default=5000)
+    args = parser.parse_args()
+
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((args.host, args.port))
+        s.listen()
+        if args.d:
+            print(f"Server listening on {args.host}:{args.port}")
+        while True:
+            conn, addr = s.accept()
+            conn = context.wrap_socket(conn, server_side=True)
+            threading.Thread(target=handle_client, args=(conn, addr, args.d), daemon=True).start()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement chat client and server directories
- add `KWS_Main.py` client with TLS support and setup script
- add simple relay server `kws_server.py`
- update README files

## Testing
- `python -m py_compile chat/*.py server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6877df5dcb1c8328b97e30bc29da4f52